### PR TITLE
Updating Error Handling

### DIFF
--- a/src/MermaidDotNet/Flowchart.cs
+++ b/src/MermaidDotNet/Flowchart.cs
@@ -133,9 +133,13 @@ public class Flowchart
         StringBuilder sb = new();
         Node? sourceNode = NavigationNodes.Find(n => n.Name == link.SourceNode);
         Node? destinationNode = NavigationNodes.Find(n => n.Name == link.DestinationNode);
-        if (sourceNode == null || destinationNode == null)
+        if (sourceNode == null )
         {
-            throw new ArgumentException("Nodes in link connection (" + link.SourceNode + "-->" + link.DestinationNode + ") not found");
+            throw new ArgumentException("Source node in link connection (" + link.SourceNode + "-->" + link.DestinationNode + ") not found");
+        }
+        if (destinationNode == null)
+        {
+            throw new ArgumentException("Destination node in link connection (" + link.SourceNode + "-->" + link.DestinationNode + ") not found");
         }
         sb.Append("    ");
         sb.Append(sourceNode.Name);


### PR DESCRIPTION
This pull request includes a change to the `AddLink(Link link)` method in the `Flowchart.cs` file. The change separates the checks for `sourceNode` and `destinationNode` being null into two different if statements, each throwing a specific error message if the respective node is not found. 

* [`src/MermaidDotNet/Flowchart.cs`](diffhunk://#diff-6e47cc720f4ac0e0d75d5f193aeaf5c362a1bab1134da7b2f5abb9a112078d9dL136-R142): Separated the check for `sourceNode` and `destinationNode` being null into two different if statements. Now, if either `sourceNode` or `destinationNode` is null, a specific error message is thrown indicating whether the source or destination node was not found in the link connection.