### PR TITLE
Enable XML documentation file generation

### DIFF
--- a/src/MermaidDotNet/MermaidDotNet.csproj
+++ b/src/MermaidDotNet/MermaidDotNet.csproj
@@ -17,6 +17,7 @@
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>
 		<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	</PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Added <GenerateDocumentationFile>True</GenerateDocumentationFile> to the <PropertyGroup> section in MermaidDotNet.csproj to configure the project to generate a documentation file during the build process.